### PR TITLE
Refactor: Make 'new chat' button reset state instead of reloading

### DIFF
--- a/GlobalContext.js
+++ b/GlobalContext.js
@@ -170,13 +170,18 @@ export const GlobalContextProvider = ({ children }) => {
         }
     };
 
+    const resetGlobalContextState = () => {
+        setOutput(null);
+        setMessageFiles(new Map());
+    };
+
     return (
         <GlobalContext.Provider value={{
             userSettings, setUserSettings, openInDrawer,
             drawerIsOpen, setDrawerIsOpen, drawerComponent, setDrawerComponent,
             pyodide, output, setOutput, deleteFile,
             isLoading, writeFile, readFile, runPython,
-            messageFiles, setMessageFiles
+            messageFiles, setMessageFiles, resetGlobalContextState
         }}>
             {children}
             <Drawer open={drawerIsOpen} onOpenChange={handleDrawerOpenChange}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,7 +26,7 @@ function Index() {
     const [streamedMessage, setStreamedMessage] = useState("");
     const [showOnboarding, setShowOnboarding] = useState(false);
     const [isToolCallsStreaming, setIsToolCallsStreaming] = useState(false);
-    const { isLoading, runPython, writeFile, readFile, deleteFile,
+    const { isLoading, runPython, writeFile, readFile, deleteFile, resetGlobalContextState,
         pyodide, userSettings, setUserSettings, openInDrawer, messageFiles } = useContext(GlobalContext);
 
     useEffect(function () {
@@ -322,7 +322,16 @@ function Index() {
 
     function handleStartNewChat() {
         if (messages.length === 0 || confirm("Are you sure you want to start a new chat?\nThis will clear the current chat history.")) {
-            window.location.reload(true);
+            // Iterate over files and delete them
+            files.forEach(file => {
+                deleteFile(`/data/${file.unique_name}`);
+            });
+            setMessages([]);
+            setFiles([]);
+            setStreamedMessage("");
+            setLoading(false);
+            setIsToolCallsStreaming(false);
+            resetGlobalContextState();
         }
     }
 


### PR DESCRIPTION
The "new chat" button functionality has been updated to provide a smoother user experience by resetting the application state directly, rather than performing a full page reload.

Changes include:
- Modified `handleStartNewChat` in `pages/index.js`:
    - Removed `window.location.reload()`.
    - Clears local component state for messages, files, streamed messages, and loading indicators.
    - Iterates through uploaded files and calls `deleteFile` (from `GlobalContext`) for each to remove them from the Pyodide virtual filesystem.
- Added `resetGlobalContextState` to `GlobalContext.js`:
    - This new function resets global states, specifically `output` (Pyodide execution results) and `messageFiles` (map of files associated with messages).
    - This function is now exported via the `GlobalContext`.
- The `resetGlobalContextState` function is called within `handleStartNewChat` in `pages/index.js` after your confirmation to ensure all relevant application states are cleared.

This change aims to make starting a new chat session faster and more efficient.